### PR TITLE
missing langrisser IV-V final edition variant

### DIFF
--- a/Named_Boxarts/Langrisser IV _ V - Final Edition (Japan) (Langrisser V Disc).png
+++ b/Named_Boxarts/Langrisser IV _ V - Final Edition (Japan) (Langrisser V Disc).png
@@ -1,0 +1,1 @@
+Langrisser IV _ V - Final Edition (Japan) (Langrisser IV Disc).png


### PR DESCRIPTION
This variant occurs when a tool that automatically creates m3u divides these two different games into two m3u of a single cd without the 'disc 1' and 'disc 2'. The one for langrisser IV already existed, but the one for langrisser V was somehow overlooked.